### PR TITLE
fix: Error out the action upon error build fail and fix the test build

### DIFF
--- a/.github/workflows/test_action.yaml
+++ b/.github/workflows/test_action.yaml
@@ -15,8 +15,3 @@ jobs:
           preset: linux
           projectDir: test-project
           package: true
-      - name: Create Artifact 
-        uses: actions/upload-artifact@v2
-        with:
-          name: Client - linux
-          path: ${{ github.workspace }}

--- a/.github/workflows/test_action.yaml
+++ b/.github/workflows/test_action.yaml
@@ -15,8 +15,3 @@ jobs:
           preset: linux
           projectDir: test-project
           package: true
-      - name: Create Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: Client - linux
-          path: ${{ github.workspace }}

--- a/.github/workflows/test_action.yaml
+++ b/.github/workflows/test_action.yaml
@@ -19,4 +19,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Client - linux
-          path: ${{ github.workspace }}/test-project/build/linux
+          path: ${{ github.workspace }}

--- a/.github/workflows/test_action.yaml
+++ b/.github/workflows/test_action.yaml
@@ -15,3 +15,8 @@ jobs:
           preset: linux
           projectDir: test-project
           package: true
+      - name: Create Artifact 
+        uses: actions/upload-artifact@v2
+        with:
+          name: Client - linux
+          path: ${{ github.workspace }}

--- a/.github/workflows/test_action.yaml
+++ b/.github/workflows/test_action.yaml
@@ -1,7 +1,6 @@
 name: Test Build Action
 on:
-  push:
-    branches: ["master", "main", "prod", "production"]
+  push
 
 jobs:
   TestAction:

--- a/.github/workflows/test_action.yaml
+++ b/.github/workflows/test_action.yaml
@@ -15,3 +15,8 @@ jobs:
           preset: linux
           projectDir: test-project
           package: true
+      - name: Create Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Client - linux
+          path: ${{ github.workspace }}/test-project/build/linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ LABEL repository="https://github.com/QuakeEye/godot-mono-build-action"
 USER root
 ADD entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
-ENTRYPOINT [ "./entrypoint.sh" ]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN ./dotnet-install.sh --version latest
 
 # Add dotnet to path
 ENV PATH="/root/.dotnet:${PATH}"
+ENV DOTNET_ROOT="/root/.dotnet"
 
 LABEL "com.github.actions.name"="Build Godot Mono"
 LABEL "com.github.actions.description"="Build a Godot mono project"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ LABEL "com.github.actions.color"="purple"
 LABEL repository="https://github.com/QuakeEye/godot-mono-build-action"
 
 USER root
-ADD entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT [ "/entrypoint.sh" ]
+ADD entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,6 @@ runs:
     - ${{ inputs.projectDir }}
     - ${{ inputs.debugMode }}
     - ${{ inputs.viewVersions }}
-    # checkforerrors
 
 branding:
   icon: "play-circle"

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,7 @@ runs:
     - ${{ inputs.package }}
     - ${{ inputs.projectDir }}
     - ${{ inputs.debugMode }}
+    # checkforerrors
 
 branding:
   icon: "play-circle"

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,9 @@ inputs:
   viewVersions:
     description: 'Prints dotnet and mono versions'
     default: false
+  runVerbose:
+    description: 'Runs Godot CLI commands in verbose mode'
+    default: false
 
 
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,9 @@ inputs:
   debugMode:
     description: 'Whether or not to use `--export-debug`'
     default: false
+  viewVersions:
+    description: 'Prints dotnet and mono versions'
+    default: false
 
 
 runs:
@@ -32,6 +35,7 @@ runs:
     - ${{ inputs.package }}
     - ${{ inputs.projectDir }}
     - ${{ inputs.debugMode }}
+    - ${{ inputs.viewVersions }}
     # checkforerrors
 
 branding:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,12 +70,12 @@ godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectory
 
 
 # Check if the build was successful by grepping the log file for a possible error message
-if grep -q "ERROR: " godot_error.log
-then
-    echo "Godot build failed. Exiting with error. This is the build log:"
-    cat godot_error.log
-    exit 1
-fi
+# if grep -q "ERROR: " godot_error.log
+# then
+#     echo "Godot build failed. Exiting with error. This is the build log:"
+#     cat godot_error.log
+#     exit 1
+# fi
 
 echo "Build Done"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ fi
 echo "Building $1 for $2"
 mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
-godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > godotheadless.log
+godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > /home/runner/work/godot-mono-build-action/godot-mono-build-action/godotheadless.log
 
 # Check the exit code of the last command
 if [ $? -ne 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -112,6 +112,8 @@ ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::ge
 
 echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
 
+cat godot_error.log
+
 # Check if the project is valid
 if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,7 +107,7 @@ fi
 # check_for_errors
 
 # A hacky way to do this but as mentioned Godot currently always returns 0
-errors=$(grep -c "Error: " godot_error.log)
+errors=$(grep -c "ERROR: " godot_error.log)
 ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
 
 echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,12 +41,12 @@ ls -la .
 godot --headless --editor --quit-after 60 ./test-project/. 2> godot_error.log
 
 # Check if the project is valid
-if grep -q "ERROR: " godot_error.log
-then
-    echo "Godot project is invalid. Exiting with error. This is the project folder population log:"
-    cat godot_error.log
-    exit 1
-fi
+# if grep -q "ERROR: " godot_error.log
+# then
+#     echo "Godot project is invalid. Exiting with error. This is the project folder population log:"
+#     cat godot_error.log
+#     exit 1
+# fi
 
 # Build the project
 echo "Building the project"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,35 +2,35 @@
 set -e
 
 
-# Function definitions
-check_for_errors() {
+# # Function definitions
+# check_for_errors() {
 
-    # Check the exit code of the last command
+#     # Check the exit code of the last command
 
-    # This method does not yet work, as godot always returns 0: https://github.com/godotengine/godot/issues/83042
-    # It would be more elegant than the current solution, so I'm leaving it here for now.
+#     # This method does not yet work, as godot always returns 0: https://github.com/godotengine/godot/issues/83042
+#     # It would be more elegant than the current solution, so I'm leaving it here for now.
 
-    # if [ $? -ne 0 ]; then
-    #   echo "Godot build failed. Exiting with error. This is the build log:"
-    #   cat godot_error.log
-    #   exit 1
-    # fi
+#     # if [ $? -ne 0 ]; then
+#     #   echo "Godot build failed. Exiting with error. This is the build log:"
+#     #   cat godot_error.log
+#     #   exit 1
+#     # fi
 
 
-    # A hacky way to do this but as mentioned Godot currently always returns 0
-    errors=$(grep -c "Error: " godot_error.log)
-    ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
+#     # A hacky way to do this but as mentioned Godot currently always returns 0
+#     errors=$(grep -c "Error: " godot_error.log)
+#     ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
 
-    echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
+#     echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
 
-    # Check if the project is valid
-    if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
-    then
-        echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
-        cat godot_error.log
-        exit 1
-    fi
-}
+#     # Check if the project is valid
+#     if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
+#     then
+#         echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
+#         cat godot_error.log
+#         exit 1
+#     fi
+# }
 
 
 # Move godot templates already installed from the docker image to home
@@ -70,9 +70,23 @@ cd "$GITHUB_WORKSPACE/$5"
 
 # Set up files required for the build
 echo "Setting up editor files required for the build"
-godot --headless --editor --quit-after 3000 . 2> godot_error.log
+godot --headless --editor --quit-after 60 . 2> godot_error.log
 
-check_for_errors
+# check_for_errors
+
+# A hacky way to do this but as mentioned Godot currently always returns 0
+errors=$(grep -c "Error: " godot_error.log)
+ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
+
+echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
+
+# Check if the project is valid
+if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
+then
+    echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
+    cat godot_error.log
+    exit 1
+fi
 
 
 # Build the project
@@ -81,7 +95,21 @@ godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectory
 
 
 # Check if the build was successful by grepping the log file for a possible error message
-check_for_errors
+# check_for_errors
+
+# A hacky way to do this but as mentioned Godot currently always returns 0
+errors=$(grep -c "Error: " godot_error.log)
+ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
+
+echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
+
+# Check if the project is valid
+if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
+then
+    echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
+    cat godot_error.log
+    exit 1
+fi
 
 
 echo "Build Done"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,37 @@
 set -e
 
 
+# Function definitions
+check_for_errors() {
+
+    # Check the exit code of the last command
+
+    # This method does not yet work, as godot always returns 0: https://github.com/godotengine/godot/issues/83042
+    # It would be more elegant than the current solution, so I'm leaving it here for now.
+
+    # if [ $? -ne 0 ]; then
+    #   echo "Godot build failed. Exiting with error. This is the build log:"
+    #   cat godot_error.log
+    #   exit 1
+    # fi
+
+
+    # A hacky way to do this but as mentioned Godot currently always returns 0
+    errors=grep -c "Error: " godot_error.log
+    ignoredErrors=grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log
+
+    echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
+
+    # Check if the project is valid
+    if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
+    then
+        echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
+        cat godot_error.log
+        exit 1
+    fi
+}
+
+
 # Move godot templates already installed from the docker image to home
 mkdir -v -p ~/.local/share/godot/export_templates
 cp -a /root/.local/share/godot/templates/. ~/.local/share/godot/export_templates/
@@ -38,44 +69,20 @@ mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
 
 # Set up files required for the build
-echo "Setting up files required for the build"
-ls -la .
+echo "Setting up editor files required for the build"
 godot --headless --editor --quit-after 3000 . 2> godot_error.log
 
-# Check if the project is valid
-# if grep -q "ERROR: " godot_error.log
-# then
-#     echo "Godot project is invalid. Exiting with error. This is the project folder population log:"
-#     cat godot_error.log
-#     exit 1
-# fi
+check_for_errors
 
-ls -la ./.godot
 
 # Build the project
 echo "Building the project"
-ls -la .
 godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 2> godot_error.log
 
 
-# Check the exit code of the last command using exit code
-
-# This method does not yet work, as godot always returns 0: https://github.com/godotengine/godot/issues/83042
-# It would be more elegant than the current solution, so I'm leaving it here for now.
-
-# if [ $? -ne 0 ]; then
-#   echo "Godot build failed. Exiting with error."
-#   exit 1
-# fi
-
-
 # Check if the build was successful by grepping the log file for a possible error message
-# if grep -q "ERROR: " godot_error.log
-# then
-#     echo "Godot build failed. Exiting with error. This is the build log:"
-#     cat godot_error.log
-#     exit 1
-# fi
+check_for_errors
+
 
 echo "Build Done"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ godot --headless --editor --quit-after 3000 . 2> godot_error.log
 #     exit 1
 # fi
 
-ls -la ./test-project/.godot
+ls -la ./.godot
 
 # Build the project
 echo "Building the project"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,12 +39,15 @@ cp -a /root/.local/share/godot/templates/. ~/.local/share/godot/export_templates
 
 
 # Verify the dotnet installation
-echo "Installed Dotnet SDK version:"
-dotnet --version
-echo "Installed Mono version:"
-mono --version
-echo "Installed dotnet runtimes:"
-dotnet --info
+if [ "$7" = "true" ]
+then
+    echo "Installed Dotnet SDK version:"
+    dotnet --version
+    echo "Installed Mono version:"
+    mono --version
+    echo "Installed dotnet runtimes:"
+    dotnet --info
+fi
 
 
 # Set the subdirectory location, if provided
@@ -127,3 +130,5 @@ then
     echo ::set-output name=artifact::package/artifact.zip
     echo "Done"
 fi
+
+exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,12 @@ fi
 echo "Building $1 for $2"
 mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
-godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > godotheadless.log 2>&1
+
+# Set up files required for the build
+godot --headless --editor --quit-after 60 .
+
+# Build the project
+godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 2> godot_error.log
 
 
 # Check the exit code of the last command using exit code
@@ -49,10 +54,10 @@ godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-
 
 
 # Check if the build was successful by grepping the log file for a possible error message
-if grep -q "ERROR: " godotheadless.log
+if grep -q "ERROR: " godot_error.log
 then
     echo "Godot build failed. Exiting with error. This is the build log:"
-    cat $godotheadless.log
+    cat $godot_error.log
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,35 +2,35 @@
 # set -e
 
 
-# # Function definitions
-# check_for_errors() {
+# Function definitions
+check_for_errors() {
 
-#     # Check the exit code of the last command
+    # Check the exit code of the last command
 
-#     # This method does not yet work, as godot always returns 0: https://github.com/godotengine/godot/issues/83042
-#     # It would be more elegant than the current solution, so I'm leaving it here for now.
+    # This method does not yet work, as godot always returns 0: https://github.com/godotengine/godot/issues/83042
+    # It would be more elegant than the current solution, so I'm leaving it here for now.
 
-#     # if [ $? -ne 0 ]; then
-#     #   echo "Godot build failed. Exiting with error. This is the build log:"
-#     #   cat godot_error.log
-#     #   exit 1
-#     # fi
+    # if [ $? -ne 0 ]; then
+    #   echo "Godot build failed. Exiting with error. This is the build log:"
+    #   cat godot_error.log
+    #   exit 1
+    # fi
 
 
-#     # A hacky way to do this but as mentioned Godot currently always returns 0
-#     errors=$(grep -c "Error: " godot_error.log)
-#     ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
+    # A hacky way to do this but as mentioned Godot currently always returns 0
+    errors=$(grep -c "Error: " godot_error.log)
+    ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
 
-#     echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
+    echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
 
-#     # Check if the project is valid
-#     if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
-#     then
-#         echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
-#         cat godot_error.log
-#         exit 1
-#     fi
-# }
+    # Check if the project is valid
+    if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
+    then
+        echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
+        cat godot_error.log
+        exit 1
+    fi
+}
 
 
 # Move godot templates already installed from the docker image to home
@@ -73,23 +73,16 @@ cd "$GITHUB_WORKSPACE/$5"
 
 # Set up files required for the build
 echo "Setting up editor files required for the build"
-# godot --headless --editor --quit-after 60 . 2> godot_error.log
 
-# check_for_errors
+if [ "$8" = "true" ]
+then
+    godot --headless --verbose --editor --quit-after 60 . 2> godot_error.log
+else
+    godot --headless --editor --quit-after 60 . 2> godot_error.log
+fi
 
-# A hacky way to do this but as mentioned Godot currently always returns 0
-# errors=$(grep -c "Error: " godot_error.log)
-# ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
 
-# echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
-
-# # Check if the project is valid
-# if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
-# then
-#     echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
-#     cat godot_error.log
-#     exit 1
-# fi
+check_for_errors
 
 
 # Build the project
@@ -104,23 +97,7 @@ fi
 
 
 # Check if the build was successful by grepping the log file for a possible error message
-# check_for_errors
-
-# A hacky way to do this but as mentioned Godot currently always returns 0
-errors=$(grep -c "ERROR: " godot_error.log)
-ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
-
-echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
-
-cat godot_error.log
-
-# Check if the project is valid
-if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
-then
-    echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
-    cat godot_error.log
-    exit 1
-fi
+check_for_errors
 
 
 echo "Build Done"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,8 @@ cd "$GITHUB_WORKSPACE/$5"
 
 # Set up files required for the build
 echo "Setting up files required for the build"
-godot --headless --editor --quit-after 60 ./test-project/ 2> godot_error.log
+ls -la .
+godot --headless --editor --quit-after 60 ./test-project/. 2> godot_error.log
 
 # Check if the project is valid
 if grep -q "ERROR: " godot_error.log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,12 +36,25 @@ mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
 godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > $GITHUB_WORKSPACE/godotheadless.log 2>&1
 
-# Check the exit code of the last command
-#  This does not yet work, as godot always returns 0: https://github.com/godotengine/godot/issues/83042
+
+# Check the exit code of the last command using exit code
+
+# This method does not yet work, as godot always returns 0: https://github.com/godotengine/godot/issues/83042
+# It would be more elegant than the current solution, so I'm leaving it here for now.
+
 # if [ $? -ne 0 ]; then
 #   echo "Godot build failed. Exiting with error."
 #   exit 1
 # fi
+
+
+# Check if the build was successful by grepping the log file for a possible error message
+grep -q "ERROR" $GITHUB_WORKSPACE/godotheadless.log
+if [ $? -ne 0 ]; then
+  echo "Godot build failed. Exiting with error."
+  exit 1
+fi
+
 
 echo "Build Done"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,13 @@ echo "Building $1 for $2"
 mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
 godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1
+
+# Check the exit code of the last command
+if [ $? -ne 0 ]; then
+  echo "Godot build failed. Exiting with error."
+  exit 1
+fi
+
 echo "Build Done"
 
 echo ::set-output name=build::build/${SubDirectoryLocation:-""}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,12 +43,14 @@ ls -la .
 godot --headless --editor --quit-after 3000 . 2> godot_error.log
 
 # Check if the project is valid
-if grep -q "ERROR: " godot_error.log
-then
-    echo "Godot project is invalid. Exiting with error. This is the project folder population log:"
-    cat godot_error.log
-    exit 1
-fi
+# if grep -q "ERROR: " godot_error.log
+# then
+#     echo "Godot project is invalid. Exiting with error. This is the project folder population log:"
+#     cat godot_error.log
+#     exit 1
+# fi
+
+ls -la ./test-project/.godot
 
 # Build the project
 echo "Building the project"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,23 +70,23 @@ cd "$GITHUB_WORKSPACE/$5"
 
 # Set up files required for the build
 echo "Setting up editor files required for the build"
-godot --headless --editor --quit-after 60 . 2> godot_error.log
+# godot --headless --editor --quit-after 60 . 2> godot_error.log
 
 # check_for_errors
 
 # A hacky way to do this but as mentioned Godot currently always returns 0
-errors=$(grep -c "Error: " godot_error.log)
-ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
+# errors=$(grep -c "Error: " godot_error.log)
+# ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
 
-echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
+# echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
 
-# Check if the project is valid
-if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
-then
-    echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
-    cat godot_error.log
-    exit 1
-fi
+# # Check if the project is valid
+# if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
+# then
+#     echo "Godot project is invalid/build has failed. Exiting with error. This is the build log:"
+#     cat godot_error.log
+#     exit 1
+# fi
 
 
 # Build the project

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,7 @@ fi
 
 # Build the project
 echo "Building the project"
+ls -la .
 godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 2> godot_error.log
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ fi
 echo "Building $1 for $2"
 mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
-godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1
+godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > godotheadless.log
 
 # Check the exit code of the last command
 if [ $? -ne 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ fi
 echo "Building $1 for $2"
 mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
-godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > $GITHUB_WORKSPACE/godotheadless.log 2>&1
+godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > godotheadless.log 2>&1
 
 
 # Check the exit code of the last command using exit code
@@ -49,9 +49,10 @@ godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-
 
 
 # Check if the build was successful by grepping the log file for a possible error message
-if grep -q "ERROR: " $GITHUB_WORKSPACE/godotheadless.log
+if grep -q "ERROR: " godotheadless.log
 then
-    echo "Godot build failed. Exiting with error."
+    echo "Godot build failed. Exiting with error. This is the build log:"
+    cat $godotheadless.log
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ cd "$GITHUB_WORKSPACE/$5"
 # Set up files required for the build
 echo "Setting up files required for the build"
 ls -la .
-godot --headless --editor --quit-after 60 ./test-project/. 2> godot_error.log
+godot --headless --editor --quit-after 60 . 2> godot_error.log
 
 # Check if the project is valid
 if grep -q "ERROR: " godot_error.log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,8 +34,7 @@ fi
 echo "Building $1 for $2"
 mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
-mkdir /home/runner/work/godot-mono-build-action/godot-mono-build-action/
-godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > /home/runner/work/godot-mono-build-action/godot-mono-build-action/godotheadless.log
+godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > $GITHUB_WORKSPACE/godotheadless.log
 
 # Check the exit code of the last command
 if [ $? -ne 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,12 +43,12 @@ ls -la .
 godot --headless --editor --quit-after 60 ./test-project/. 2> godot_error.log
 
 # Check if the project is valid
-# if grep -q "ERROR: " godot_error.log
-# then
-#     echo "Godot project is invalid. Exiting with error. This is the project folder population log:"
-#     cat godot_error.log
-#     exit 1
-# fi
+if grep -q "ERROR: " godot_error.log
+then
+    echo "Godot project is invalid. Exiting with error. This is the project folder population log:"
+    cat godot_error.log
+    exit 1
+fi
 
 # Build the project
 echo "Building the project"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,12 +36,12 @@ mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
 
 # Set up files required for the build
-godot --headless --editor --quit-after 60 . 2> godot_error.log
+godot --headless --editor --quit-after 60 ./test-project/ 2> godot_error.log
 
 # Check if the project is valid
 if grep -q "ERROR: " godot_error.log
 then
-    echo "Godot project is invalid. Exiting with error. This is the build log:"
+    echo "Godot project is invalid. Exiting with error. This is the project folder population log:"
     cat godot_error.log
     exit 1
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectory
 if grep -q "ERROR: " godot_error.log
 then
     echo "Godot build failed. Exiting with error. This is the build log:"
-    cat $godot_error.log
+    cat godot_error.log
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,13 +34,14 @@ fi
 echo "Building $1 for $2"
 mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
-godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > $GITHUB_WORKSPACE/godotheadless.log
+godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > $GITHUB_WORKSPACE/godotheadless.log 2>&1
 
 # Check the exit code of the last command
-if [ $? -ne 0 ]; then
-  echo "Godot build failed. Exiting with error."
-  exit 1
-fi
+#  This does not yet work, as godot always returns 0: https://github.com/godotengine/godot/issues/83042
+# if [ $? -ne 0 ]; then
+#   echo "Godot build failed. Exiting with error."
+#   exit 1
+# fi
 
 echo "Build Done"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,7 @@ fi
 echo "Building $1 for $2"
 mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
+mkdir /home/runner/work/godot-mono-build-action/godot-mono-build-action/
 godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 > /home/runner/work/godot-mono-build-action/godot-mono-build-action/godotheadless.log
 
 # Check the exit code of the last command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,15 @@ mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
 
 # Set up files required for the build
-godot --headless --editor --quit-after 60 .
+godot --headless --editor --quit-after 60 . 2> godot_error.log
+
+# Check if the project is valid
+if grep -q "ERROR: " godot_error.log
+then
+    echo "Godot project is invalid. Exiting with error. This is the build log:"
+    cat $godot_error.log
+    exit 1
+fi
 
 # Build the project
 godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 2> godot_error.log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ godot --headless --editor --quit-after 60 . 2> godot_error.log
 if grep -q "ERROR: " godot_error.log
 then
     echo "Godot project is invalid. Exiting with error. This is the build log:"
-    cat $godot_error.log
+    cat godot_error.log
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,7 @@ mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
 
 # Set up files required for the build
+echo "Setting up files required for the build"
 godot --headless --editor --quit-after 60 ./test-project/ 2> godot_error.log
 
 # Check if the project is valid
@@ -47,6 +48,7 @@ then
 fi
 
 # Build the project
+echo "Building the project"
 godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 2> godot_error.log
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,8 +18,8 @@ check_for_errors() {
 
 
     # A hacky way to do this but as mentioned Godot currently always returns 0
-    errors=grep -c "Error: " godot_error.log
-    ignoredErrors=grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log
+    errors=$(grep -c "Error: " godot_error.log)
+    ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
 
     echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,8 @@ echo "Installed Dotnet SDK version:"
 dotnet --version
 echo "Installed Mono version:"
 mono --version
+echo "Installed dotnet runtimes:"
+dotnet --info
 
 
 # Set the subdirectory location, if provided

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# set -e
+# set -e        # This can be re-enabled once Godot CLI gives back proper exit codes
 
 
 # Function definitions
@@ -21,7 +21,7 @@ check_for_errors() {
     errors=$(grep -c "ERROR: " godot_error.log)
     ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
 
-    echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."
+    echo "Found $errors error(s) in the project. Ignoring $ignoredErrors error(s)."
 
     # Check if the project is valid
     if [ $errors -gt 0 ] && [ $errors -gt $ignoredErrors ]
@@ -38,7 +38,7 @@ mkdir -v -p ~/.local/share/godot/export_templates
 cp -a /root/.local/share/godot/templates/. ~/.local/share/godot/export_templates/
 
 
-# Verify the dotnet installation
+# Verify/print the dotnet installation
 if [ "$7" = "true" ]
 then
     echo "Installed Dotnet SDK version:"
@@ -71,6 +71,7 @@ echo "Building $1 for $2"
 mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
 cd "$GITHUB_WORKSPACE/$5"
 
+
 # Set up files required for the build
 echo "Setting up editor files required for the build"
 
@@ -80,7 +81,6 @@ then
 else
     godot --headless --editor --quit-after 60 . 2> godot_error.log
 fi
-
 
 check_for_errors
 
@@ -95,13 +95,10 @@ else
     godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 2> godot_error.log
 fi
 
-
-# Check if the build was successful by grepping the log file for a possible error message
 check_for_errors
 
 
 echo "Build Done"
-
 echo ::set-output name=build::build/${SubDirectoryLocation:-""}
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+# set -e
 
 
 # # Function definitions

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,12 +49,11 @@ godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-
 
 
 # Check if the build was successful by grepping the log file for a possible error message
-grep -q "ERROR" $GITHUB_WORKSPACE/godotheadless.log
-if [ $? -ne 0 ]; then
-  echo "Godot build failed. Exiting with error."
-  exit 1
+if grep -q "ERROR: " $GITHUB_WORKSPACE/godotheadless.log
+then
+    echo "Godot build failed. Exiting with error."
+    exit 1
 fi
-
 
 echo "Build Done"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ cd "$GITHUB_WORKSPACE/$5"
 # Set up files required for the build
 echo "Setting up files required for the build"
 ls -la .
-godot --headless --editor . 2> godot_error.log
+godot --headless --editor --quit-after 3000 . 2> godot_error.log
 
 # Check if the project is valid
 if grep -q "ERROR: " godot_error.log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,7 +94,13 @@ echo "Setting up editor files required for the build"
 
 # Build the project
 echo "Building the project"
-godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 2> godot_error.log
+
+if [ "$8" = "true" ]
+then
+    godot --headless --verbose --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 2> godot_error.log
+else
+    godot --headless --${mode} "$2" $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1 2> godot_error.log
+fi
 
 
 # Check if the build was successful by grepping the log file for a possible error message

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ check_for_errors() {
 
 
     # A hacky way to do this but as mentioned Godot currently always returns 0
-    errors=$(grep -c "Error: " godot_error.log)
+    errors=$(grep -c "ERROR: " godot_error.log)
     ignoredErrors=$(grep -c "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" godot_error.log)
 
     echo "Found $errors errors in the project. Ignoring $ignoredErrors errors."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ cd "$GITHUB_WORKSPACE/$5"
 # Set up files required for the build
 echo "Setting up files required for the build"
 ls -la .
-godot --headless --editor --quit-after 60 . 2> godot_error.log
+godot --headless --editor . 2> godot_error.log
 
 # Check if the project is valid
 if grep -q "ERROR: " godot_error.log

--- a/test-project/export_presets.cfg
+++ b/test-project/export_presets.cfg
@@ -2,7 +2,7 @@
 
 name="linux"
 platform="Linux/X11"
-runnable=false
+runnable=true
 dedicated_server=false
 custom_features=""
 export_filter="all_resources"

--- a/test-project/icon.svg.import
+++ b/test-project/icon.svg.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://dxy016iem3bdl"
+uid="uid://cyctn3n7wrukg"
 path="res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.ctex"
 metadata={
 "vram_texture": false

--- a/test-project/project.csproj
+++ b/test-project/project.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Godot.NET.Sdk/4.2.1">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net7.0</TargetFramework>
+    <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'ios' ">net8.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+  </PropertyGroup>
+</Project>

--- a/test-project/project.sln
+++ b/test-project/project.sln
@@ -1,0 +1,19 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "project", "project.csproj", "{49B1C7E4-A866-4914-A68C-1ECF8B6538F1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+	Debug|Any CPU = Debug|Any CPU
+	ExportDebug|Any CPU = ExportDebug|Any CPU
+	ExportRelease|Any CPU = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{49B1C7E4-A866-4914-A68C-1ECF8B6538F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49B1C7E4-A866-4914-A68C-1ECF8B6538F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49B1C7E4-A866-4914-A68C-1ECF8B6538F1}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{49B1C7E4-A866-4914-A68C-1ECF8B6538F1}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{49B1C7E4-A866-4914-A68C-1ECF8B6538F1}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{49B1C7E4-A866-4914-A68C-1ECF8B6538F1}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This pull request aims to error out the action upon build fail and to fix up the build itself.

## Error out
This has been handled in the PR and now works successfully, but might require tweaking later when godot updates the CLI to be able to have proper exit codes.
This fixes #3.

## Fixing the test build
Currently trying to build results in the following error:
```sh
ERROR: Condition "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" is true. Returning: Variant()
   at: _EDITOR_GET (editor/editor_settings.cpp:1140)
```
as mentioned in #5.